### PR TITLE
Create confirm=c mode for non-destructive installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,13 @@ Usage: java -jar <jarfile> -o <package_file> [options] [[component]...]
         --spec <file>      : a specification file listing application components
 ```
 
+
 The resulting file is a runnable `.jar` file that will install the application!
+```fortran
+Usage: java -jar <package_file> [option]
+   Valid option is either:
+        -y         : automatically reply 'Y' to all confirmation (install/delete) messages
+        -c         : automatically reply 'Y' to all non-destructive (install) confirmation messages
+``` 
+
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Universal application installer for IBM i
 
 To build an application installation image:
 ```fortran
-Usage: java -jar <jarfile> -o <package_file> [options] [[component]...]
+Usage: java -jar appinstall-ibmi-xxx.jar -o <package_file> [options] [[component]...]
 
   <package_file> is the file name of the build package you are creating
     (.jar file extension is preferred)

--- a/README.md
+++ b/README.md
@@ -14,23 +14,29 @@ Usage: java -jar <jarfile> -o <package_file> [options] [[component]...]
        -v          : verbose mode
        --version   : print version information
        -h/--help   : print this help
+       --lodrun <library> : save QINSTAPP program from <library> to be used by LODRUN, below
+       --spec <file>      : a specification file listing application components
 
   Multiple components can be specified. These identify components
   of the application for which you are creating an installer.
-    Valid component values include:
-        --qsys <library>   : a library in the QSYS.LIB file system
-        --dir <dir>        : a directory (contents are not included)
-        --file <file/dir>  : a file or directory (if a directory, contents are included)
-        --spec <file>      : a specification file listing application components
+   Valid component values include:
+       --qsys <library>   : a library in the QSYS.LIB file system
+       --dir <dir>        : a directory (contents are not included)
+       --file <file/dir>  : a file or directory (if a directory, contents are included)
 ```
 
 
 The resulting file is a runnable `.jar` file that will install the application!
 ```fortran
 Usage: java -jar <package_file> [option]
-   Valid option is either:
-        -y         : automatically reply 'Y' to all confirmation (install/delete) messages
-        -c         : automatically reply 'Y' to all non-destructive (install) confirmation messages
+   Valid options include:
+       -v          : verbose mode
+       -y          : automatically reply 'Y' to all confirmation (install/delete) messages
+       -c          : automatically reply 'Y' to all non-destructive (install) confirmation messages
+       -l/--lodrun : do LODRUN instead of directly restoring (if specified, the following --rstxxx options are ignored)
+       --rstlib <library>   : override restore library
+       --rstasp <asp>       : override restore asp
+       --rstaspdev <aspdev> : override restore asp device
 ``` 
 
 

--- a/src/main/java/com/github/theprez/appinstall/AppInstall.java
+++ b/src/main/java/com/github/theprez/appinstall/AppInstall.java
@@ -29,6 +29,8 @@ public class AppInstall {
                     builder.addFile(_args.removeFirst());
                 } else if ("--spec".equalsIgnoreCase(arg)) {
                     builder.addFromSpecFile(_logger, _args.removeFirst());
+                } else if ("--lodrun".equalsIgnoreCase(arg)) {
+                    builder.setLodrunLib(_logger, _args.removeFirst());
                 } else {
                     _logger.println_err("Urecognized argument: " + arg);
                     _logger.println();
@@ -41,12 +43,12 @@ public class AppInstall {
         }
     }
 
-    private static void doInstall(final AppLogger _logger, char _confirm) throws IOException, InterruptedException, ObjectDoesNotExistException, PropertyVetoException {
+    private static void doInstall(final AppLogger _logger, InstallOptions installOptions) throws IOException, InterruptedException, ObjectDoesNotExistException, PropertyVetoException {
             _logger.println("Doing the installation");
             final PackageConfiguration config = new PackageConfiguration(_logger);
             final ExtractionTask extraction = new ExtractionTask(_logger, config);
             final InstallationTask install = new InstallationTask(_logger, config, extraction.run());
-            install.run(_confirm);
+            install.run(installOptions);
     }
 
     private static boolean isInstallPackage() {
@@ -63,9 +65,25 @@ public class AppInstall {
                 printVersionInfo(logger);
                 System.exit(0);
             } else if (isInstallPackage()) {
+            	InstallOptions installOptions = new InstallOptions();
             	// Allow either -y='yes to all ' or -c 'continue if not delete'
-            	char confirm= args.remove("-y") ? 'y' : args.remove("-c") ? 'c' : ' ';
-                doInstall(logger, confirm);
+            	installOptions.confirm = args.remove("-y") ? 'y' : args.remove("-c") ? 'c' : ' ';
+            	installOptions.lodrun = args.remove("-l") || args.remove("--lodrun");
+            	// Allow --rstlib/rstasp/rstaspdev
+                while (!args.isEmpty()) {
+                	String arg = args.removeFirst().toLowerCase();
+                	switch (arg) {
+                		case "--rstlib":
+                			installOptions.rstlib = args.removeFirst();
+                			break;
+                		case "--rstasp":
+                			installOptions.rstasp = args.removeFirst();
+                			break;
+                		case "--rstaspdev":
+                			installOptions.rstaspdev = args.removeFirst();
+                	}
+                }
+                doInstall(logger, installOptions);
             } else {
                 doBuild(logger, args);
             }

--- a/src/main/java/com/github/theprez/appinstall/AppInstall.java
+++ b/src/main/java/com/github/theprez/appinstall/AppInstall.java
@@ -41,12 +41,12 @@ public class AppInstall {
         }
     }
 
-    private static void doInstall(final AppLogger _logger, boolean _yesMode) throws IOException, InterruptedException, ObjectDoesNotExistException, PropertyVetoException {
+    private static void doInstall(final AppLogger _logger, char _confirm) throws IOException, InterruptedException, ObjectDoesNotExistException, PropertyVetoException {
             _logger.println("Doing the installation");
             final PackageConfiguration config = new PackageConfiguration(_logger);
             final ExtractionTask extraction = new ExtractionTask(_logger, config);
             final InstallationTask install = new InstallationTask(_logger, config, extraction.run());
-            install.run(_yesMode);
+            install.run(_confirm);
     }
 
     private static boolean isInstallPackage() {
@@ -63,7 +63,9 @@ public class AppInstall {
                 printVersionInfo(logger);
                 System.exit(0);
             } else if (isInstallPackage()) {
-                doInstall(logger, args.remove("-y"));
+            	// Allow either -y='yes to all ' or -c 'continue if not delete'
+            	char confirm= args.remove("-y") ? 'y' : args.remove("-c") ? 'c' : ' ';
+                doInstall(logger, confirm);
             } else {
                 doBuild(logger, args);
             }

--- a/src/main/java/com/github/theprez/appinstall/InstallOptions.java
+++ b/src/main/java/com/github/theprez/appinstall/InstallOptions.java
@@ -1,0 +1,9 @@
+package com.github.theprez.appinstall;
+
+public class InstallOptions {
+	char confirm;
+	boolean lodrun;
+	String rstlib;
+	String rstasp;
+	String rstaspdev;
+}

--- a/src/main/java/com/github/theprez/appinstall/InstallPackageBuilder.java
+++ b/src/main/java/com/github/theprez/appinstall/InstallPackageBuilder.java
@@ -14,7 +14,6 @@ import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -131,7 +130,6 @@ public class InstallPackageBuilder {
     }
 
     public void addFromSpecFile(final AppLogger _logger, final String _specFile) throws UnsupportedEncodingException, FileNotFoundException, IOException {
-        final String line = "";
         try (BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(_specFile), "UTF-8"))) {
             throw new IOException("not implemented");
         }
@@ -178,7 +176,7 @@ public class InstallPackageBuilder {
         }
 
         // package up libraries
-        final AS400 as400 = new AS400("localhost", "*CURRENT", "*CURRENT");
+        final AS400 as400 = new AS400("localhost", "*CURRENT");
         try {
             for (final String library : m_libraries) {
                 m_logger.printfln("Saving library %s...", library);


### PR DESCRIPTION
@ThePrez  I needed to add a "non-destructive" confirmation mode slightly different than your "yes-mode" to get this to work from a `yum install` perspective, and I included up some deprecated/other warnings so that everything compiles cleanly.