### PR TITLE
Add `--fileIfMissing` and `--dirIfMissing` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,32 +11,33 @@ Usage: java -jar appinstall-ibmi-xxx.jar -o <package_file> [options] [[component
     (.jar file extension is preferred)
 
    Valid options include:
-       -v          : verbose mode
-       --version   : print version information
-       -h/--help   : print this help
+       -v                 : verbose mode
+       --version          : print version information
+       -h/--help          : print this help
        --lodrun <library> : save QINSTAPP program from <library> to be used by LODRUN, below
        --spec <file>      : a specification file listing application components
 
   Multiple components can be specified. These identify components
   of the application for which you are creating an installer.
     Valid component values include:
-        --qsys <library>   : a library in the QSYS.LIB file system
-        --dir  <dir>        : a directory (contents are not included)
-        --file <file/dir>  : a file or directory (if a directory, contents are included)
-        --pre  <file>      : a pre-install script (only one can be specified)
-        --post <file>      : a post-install script (only one can be specified)
-        --spec <file>      : a specification file listing application components
+        --qsys <library>           : a library in the QSYS.LIB file system
+        --dir  <dir>               : a directory (contents are not included)
+        --dirIfMissing  <dir>      : a directory (contents are not included) - only installed if missing
+        --file <file/dir>          : a file or directory (if a directory, contents are included)
+        --fileIfMissing <file/dir> : a file or directory (if a directory, contents are included) - only installed if missing
+        --pre  <file>              : a pre-install script (only one can be specified)
+        --post <file>              : a post-install script (only one can be specified)
+        --spec <file>              : a specification file listing application components
 ```
-
 
 The resulting file is a runnable `.jar` file that will install the application!
 ```fortran
 Usage: java -jar <package_file> [option]
    Valid options include:
-       -v          : verbose mode
-       -y          : automatically reply 'Y' to all confirmation (install/delete) messages
-       -c          : automatically reply 'Y' to all non-destructive (install) confirmation messages
-       -l/--lodrun : do LODRUN instead of directly restoring (if specified, the following --rstxxx options are ignored)
+       -v                   : verbose mode
+       -y                   : automatically reply 'Y' to all confirmation (install/delete) messages
+       -c                   : automatically reply 'Y' to all non-destructive (install) confirmation messages
+       -l/--lodrun          : do LODRUN instead of directly restoring (if specified, the following --rstxxx options are ignored)
        --rstlib <library>   : override restore library
        --rstasp <asp>       : override restore asp
        --rstaspdev <aspdev> : override restore asp device

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <groupId>io.github.theprez</groupId>
   <artifactId>appinstall-ibmi</artifactId>
   <packaging>jar</packaging>
-  <version>0.0.5</version>
+  <version>0.0.6</version>
 
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <groupId>io.github.theprez</groupId>
   <artifactId>appinstall-ibmi</artifactId>
   <packaging>jar</packaging>
-  <version>0.0.1</version>
+  <version>0.0.5</version>
 
 
   <properties>

--- a/src/main/java/com/github/theprez/appinstall/AppInstall.java
+++ b/src/main/java/com/github/theprez/appinstall/AppInstall.java
@@ -28,9 +28,13 @@ public class AppInstall {
                 } else if ("--qsys".equalsIgnoreCase(arg)) {
                     builder.addLibrary(_args.removeFirst());
                 } else if ("--dir".equalsIgnoreCase(arg)) {
-                    builder.addBareDirectory(_args.removeFirst());
+                    builder.addBareDirectory(_args.removeFirst(), false);
+                } else if ("--dirIfMissing".equalsIgnoreCase(arg)) {
+                    builder.addBareDirectory(_args.removeFirst(), true);
                 } else if ("--file".equalsIgnoreCase(arg)) {
-                    builder.addFile(_args.removeFirst());
+                    builder.addFile(_args.removeFirst(), false);
+                } else if ("--fileIfMissing".equalsIgnoreCase(arg)) {
+                    builder.addFile(_args.removeFirst(), true);
                 } else if ("--spec".equalsIgnoreCase(arg)) {
                     builder.addFromSpecFile(_logger, _args.removeFirst());
                 } else if ("--lodrun".equalsIgnoreCase(arg)) {

--- a/src/main/java/com/github/theprez/appinstall/InstallPackageBuilder.java
+++ b/src/main/java/com/github/theprez/appinstall/InstallPackageBuilder.java
@@ -46,11 +46,7 @@ import com.ibm.as400.access.ObjectDoesNotExistException;
 import com.ibm.as400.access.QueuedMessage;
 
 public class InstallPackageBuilder {
-    static synchronized void runCommand(final AppLogger _logger, final AS400 _as400, final String _cmd,
-            final boolean _isOkToFail) throws IOException, ObjectDoesNotExistException, PropertyVetoException { // TODO:
-                                                                                                                // where
-                                                                                                                // should
-                                                                                                                // this
+    static synchronized void runCommand(final AppLogger _logger, final AS400 _as400, final String _cmd, final boolean _isOkToFail) throws IOException, ObjectDoesNotExistException, PropertyVetoException { // TODO: where should this
         // live?
         try {
             _logger.printfln_verbose("Running CL command '%s'", _cmd);

--- a/src/main/java/com/github/theprez/appinstall/InstallPackageBuilder.java
+++ b/src/main/java/com/github/theprez/appinstall/InstallPackageBuilder.java
@@ -16,7 +16,6 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -47,7 +46,11 @@ import com.ibm.as400.access.ObjectDoesNotExistException;
 import com.ibm.as400.access.QueuedMessage;
 
 public class InstallPackageBuilder {
-    static synchronized void runCommand(final AppLogger _logger, final AS400 _as400, final String _cmd, final boolean _isOkToFail) throws IOException, ObjectDoesNotExistException, PropertyVetoException { // TODO: where should this
+    static synchronized void runCommand(final AppLogger _logger, final AS400 _as400, final String _cmd,
+            final boolean _isOkToFail) throws IOException, ObjectDoesNotExistException, PropertyVetoException { // TODO:
+                                                                                                                // where
+                                                                                                                // should
+                                                                                                                // this
         // live?
         try {
             _logger.printfln_verbose("Running CL command '%s'", _cmd);
@@ -70,7 +73,7 @@ public class InstallPackageBuilder {
                 jobLog.load();
                 final QueuedMessage[] jobLogMsgs = jobLog.getMessages(jobLogPos, jobLog.getLength());
                 for (final QueuedMessage jobLogMsg : jobLogMsgs) {
-                    if(AS400Message.INFORMATIONAL == jobLogMsg.getType()) {
+                    if (AS400Message.INFORMATIONAL == jobLogMsg.getType()) {
                         continue;
                     }
                     _logger.printfln("    %s: %s", jobLogMsg.getID(), jobLogMsg.getText());
@@ -98,12 +101,13 @@ public class InstallPackageBuilder {
     private File m_preInstall;
     private File m_postInstall;
     private final Set<File> m_files = new TreeSet<File>();
+    private final Set<File> m_files_if_missing = new TreeSet<File>();
     private final Set<String> m_libraries = new TreeSet<String>();
 
     private final AppLogger m_logger;
 
     private File m_outputFile = null;
-	private String m_lodrunLib;
+    private String m_lodrunLib;
 
     public InstallPackageBuilder(final AppLogger _logger) {
         m_logger = _logger;
@@ -143,28 +147,45 @@ public class InstallPackageBuilder {
         }
     }
 
-    public void addBareDirectory(final String _dir) throws IOException {
+    public void addBareDirectory(final String _dir, boolean ifMissing) throws IOException {
         final File dir = verifyDir(_dir);
-        m_files.add(dir);
-    }
-
-    public void addFile(final File _f) throws IOException {
-        final File f = verifyExists(_f);
-        if (f.isDirectory()) {
-            m_files.add(f);
-            for (final File child : f.listFiles()) {
-                addFile(child);
-            }
+        if (ifMissing) {
+            m_files_if_missing.add(dir);
         } else {
-            m_files.add(f);
+            m_files.add(dir);
         }
     }
 
-    public void addFile(final String _f) throws IOException {
-        addFile(new File(_f));
+    public void addFile(final File _f, boolean ifMissing) throws IOException {
+        final File f = verifyExists(_f);
+        if (f.isDirectory()) {
+            // Add directory
+            if (ifMissing) {
+                m_files_if_missing.add(f);
+            } else {
+                m_files.add(f);
+            }
+
+            // Add files in directory
+            for (final File child : f.listFiles()) {
+                addFile(child, ifMissing);
+            }
+        } else {
+            // Add file
+            if (ifMissing) {
+                m_files_if_missing.add(f);
+            } else {
+                m_files.add(f);
+            }
+        }
     }
 
-    public void addFromSpecFile(final AppLogger _logger, final String _specFile) throws UnsupportedEncodingException, FileNotFoundException, IOException {
+    public void addFile(final String _f, boolean ifMissing) throws IOException {
+        addFile(new File(_f), ifMissing);
+    }
+
+    public void addFromSpecFile(final AppLogger _logger, final String _specFile)
+            throws UnsupportedEncodingException, FileNotFoundException, IOException {
         try (BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(_specFile), "UTF-8"))) {
             throw new IOException("not implemented");
         }
@@ -180,10 +201,11 @@ public class InstallPackageBuilder {
     }
 
     public void setLodrunLib(final AppLogger _logger, final String _lib) {
-    	m_lodrunLib = _lib;
+        m_lodrunLib = _lib;
     }
 
-    public void build() throws IOException, URISyntaxException, InterruptedException, ObjectDoesNotExistException, PropertyVetoException {
+    public void build() throws IOException, URISyntaxException, InterruptedException, ObjectDoesNotExistException,
+            PropertyVetoException {
         if (null == m_outputFile) {
             throw new IOException("Output file not specified");
         } // TODO: check if exists
@@ -221,24 +243,35 @@ public class InstallPackageBuilder {
         }
 
         // package up stream files
-        if (!m_files.isEmpty()) {
-            m_logger.println("Saving stream files...");
-            final File tarFile = new File(m_dir, "files.tar");
-            boolean isCreating = true;
-            for (final File file : m_files) {
-                m_logger.printfln_verbose("Packaging file '%s'...", file.getAbsolutePath());
-                final Process p = Runtime.getRuntime().exec(new String[] { "/QOpenSys/usr/bin/tar", "-D", isCreating ? "-cvf" : "-uvf", tarFile.getName(), file.getAbsolutePath() }, new String[] { "QIBM_PASE_DESCRIPTOR_STDIO=B" }, m_dir);
-                ProcessLauncher.pipeStreamsToCurrentProcess("TAR", p, m_logger);
-                if(0 !=p.waitFor()) {
-                    throw new IOException("Error packaging stream files");
+        Map<String, Set<File>> fileGroups = new LinkedHashMap<>();
+        fileGroups.put("files.tar", m_files);
+        fileGroups.put("filesIfMissing.tar", m_files_if_missing);
+        for (Map.Entry<String, Set<File>> entry : fileGroups.entrySet()) {
+            String tarName = entry.getKey();
+            Set<File> files = entry.getValue();
+
+            if (!files.isEmpty()) {
+                m_logger.println("Saving stream files...");
+                final File tarFile = new File(m_dir, tarName);
+                boolean isCreating = true;
+                for (final File file : files) {
+                    m_logger.printfln_verbose("Packaging file '%s'...", file.getAbsolutePath());
+                    final Process p = Runtime.getRuntime()
+                            .exec(new String[] { "/QOpenSys/usr/bin/tar", "-D", isCreating ? "-cvf" : "-uvf",
+                                    tarFile.getName(), file.getAbsolutePath() },
+                                    new String[] { "QIBM_PASE_DESCRIPTOR_STDIO=B" }, m_dir);
+                    ProcessLauncher.pipeStreamsToCurrentProcess("TAR", p, m_logger);
+                    if (0 != p.waitFor()) {
+                        throw new IOException("Error packaging stream files");
+                    }
+                    isCreating = false;
                 }
-                isCreating = false;
-            }
-            manifestFiles.add(tarFile.getName());
-            // Assume lodrun installs files
-            if (m_lodrunLib==null) {
-            	final String untarCmd = "/QOpenSys/usr/bin/tar xvf files.tar -C /.";
-	            manifestCommands.add(untarCmd);
+                manifestFiles.add(tarFile.getName());
+                // Assume lodrun installs files
+                if (m_lodrunLib == null) {
+                    final String untarCmd = "/QOpenSys/usr/bin/tar xvf " + tarName + " -C /.";
+                    manifestCommands.add(untarCmd);
+                }
             }
         }
 
@@ -250,36 +283,50 @@ public class InstallPackageBuilder {
                 runCommand(as400, "CRTSAVF QTEMP/" + library, false);
                 runCommand(as400, "SAVLIB LIB(" + library + ") DEV(*SAVF) SAVF(QTEMP/" + library + ")", false);
                 final File stmf = new File(m_dir, library + ".lib");
-                runCommand(as400, "CPYTOSTMF FROMMBR('/qsys.lib/qtemp.lib/" + library + ".file') TOSTMF('" + stmf.getAbsolutePath() + "') STMFOPT(*REPLACE) CVTDTA(*NONE) ENDLINFMT(*FIXED)", false);
+                runCommand(as400,
+                        "CPYTOSTMF FROMMBR('/qsys.lib/qtemp.lib/" + library + ".file') TOSTMF('"
+                                + stmf.getAbsolutePath() + "') STMFOPT(*REPLACE) CVTDTA(*NONE) ENDLINFMT(*FIXED)",
+                        false);
                 manifestFiles.add(stmf.getName());
-                
+
                 manifestCommands.add("CRTSAVF QTEMP/" + library);
-                manifestCommands.add("CPYFRMSTMF FROMSTMF('$PWD/" + stmf.getName() + "') TOMBR('/qsys.lib/qtemp.lib/" + library + ".file') MBROPT(*REPLACE) CVTDTA(*NONE) ENDLINFMT(*FIXED) TABEXPN(*NO)");
+                manifestCommands.add("CPYFRMSTMF FROMSTMF('$PWD/" + stmf.getName() + "') TOMBR('/qsys.lib/qtemp.lib/"
+                        + library + ".file') MBROPT(*REPLACE) CVTDTA(*NONE) ENDLINFMT(*FIXED) TABEXPN(*NO)");
                 // Assume lodrun installs libraries
-                if (m_lodrunLib==null) {
-	                // TODO: conditionally DLTLIB first
-	                manifestCommands.add("DLTLIB " + library);
-	                manifestCommands.add("RSTLIB SAVLIB(" + library + ") DEV(*SAVF) SAVF(QTEMP/" + library + ") MBROPT(*ALL) ALWOBJDIF(*ALL) RSTLIB(" + library + ")");
+                if (m_lodrunLib == null) {
+                    // TODO: conditionally DLTLIB first
+                    manifestCommands.add("DLTLIB " + library);
+                    manifestCommands.add("RSTLIB SAVLIB(" + library + ") DEV(*SAVF) SAVF(QTEMP/" + library
+                            + ") MBROPT(*ALL) ALWOBJDIF(*ALL) RSTLIB(" + library + ")");
                 }
             }
-            
+
             // Create LODRUN QINSTAPP save file
             if (m_lodrunLib != null) {
                 m_logger.printfln("Creating QINSTAPP save file...");
                 runCommand(as400, "CRTSAVF QTEMP/QINSTAPP", false);
-            	// SAVOBJ/RSTOBJ QINSTAPP to QTEMP if needed (instead of CRTDUPOBJ to preserve attributes)
+                // SAVOBJ/RSTOBJ QINSTAPP to QTEMP if needed (instead of CRTDUPOBJ to preserve
+                // attributes)
                 if (!"QTEMP".equalsIgnoreCase(m_lodrunLib)) {
-                    runCommand(as400, "SAVOBJ OBJ(QINSTAPP) OBJTYPE(*PGM) DEV(*SAVF) SAVF(QTEMP/QINSTAPP) LIB(" + m_lodrunLib + ')', false);
-                    runCommand(as400, "RSTOBJ OBJ(QINSTAPP) OBJTYPE(*PGM) DEV(*SAVF) SAVF(QTEMP/QINSTAPP) RSTLIB(QTEMP) ALWOBJDIF(*ALL) MBROPT(*ALL) SAVLIB(" + m_lodrunLib + ')', false);
+                    runCommand(as400, "SAVOBJ OBJ(QINSTAPP) OBJTYPE(*PGM) DEV(*SAVF) SAVF(QTEMP/QINSTAPP) LIB("
+                            + m_lodrunLib + ')', false);
+                    runCommand(as400,
+                            "RSTOBJ OBJ(QINSTAPP) OBJTYPE(*PGM) DEV(*SAVF) SAVF(QTEMP/QINSTAPP) RSTLIB(QTEMP) ALWOBJDIF(*ALL) MBROPT(*ALL) SAVLIB("
+                                    + m_lodrunLib + ')',
+                            false);
                     runCommand(as400, "CLRSAVF QTEMP/QINSTAPP", false);
                 }
-                runCommand(as400, "SAVOBJ OBJ(QINSTAPP) OBJTYPE(*PGM) DEV(*SAVF) SAVF(QTEMP/QINSTAPP) LIB(QTEMP)", false);;
+                runCommand(as400, "SAVOBJ OBJ(QINSTAPP) OBJTYPE(*PGM) DEV(*SAVF) SAVF(QTEMP/QINSTAPP) LIB(QTEMP)",
+                        false);
+                ;
                 final File stmf = new File(m_dir, "qinstapp.pgm");
-                runCommand(as400, "CPYTOSTMF FROMMBR('/qsys.lib/qtemp.lib/qinstapp.file') TOSTMF('" + stmf.getAbsolutePath() + "') CVTDTA(*NONE) ENDLINFMT(*FIXED)", false);
+                runCommand(as400, "CPYTOSTMF FROMMBR('/qsys.lib/qtemp.lib/qinstapp.file') TOSTMF('"
+                        + stmf.getAbsolutePath() + "') CVTDTA(*NONE) ENDLINFMT(*FIXED)", false);
                 manifestFiles.add(stmf.getName());
-                
+
                 manifestCommands.add("CRTSAVF QTEMP/QINSTAPP");
-                manifestCommands.add("CPYFRMSTMF FROMSTMF('$PWD/" + stmf.getName() + "') TOMBR('/qsys.lib/qtemp.lib/qinstapp.file') MBROPT(*REPLACE) CVTDTA(*NONE) ENDLINFMT(*FIXED) TABEXPN(*NO)");
+                manifestCommands.add("CPYFRMSTMF FROMSTMF('$PWD/" + stmf.getName()
+                        + "') TOMBR('/qsys.lib/qtemp.lib/qinstapp.file') MBROPT(*REPLACE) CVTDTA(*NONE) ENDLINFMT(*FIXED) TABEXPN(*NO)");
                 manifestCommands.add("LODRUN DEV(*SAVF) SAVF(QTEMP/QINSTAPP)");
             }
         } finally {
@@ -321,10 +368,10 @@ public class InstallPackageBuilder {
             m_logger.println_verbose("done adding our manifest");
 
             // add pre/post install scripts
-            if(preInstall != null) {
+            if (preInstall != null) {
                 manifestFiles.add(preInstall.getName());
             }
-            if(postInstall != null) {
+            if (postInstall != null) {
                 manifestFiles.add(postInstall.getName());
             }
 
@@ -342,7 +389,8 @@ public class InstallPackageBuilder {
         }
     }
 
-    private void runCommand(final AS400 _as400, final String _cmd, final boolean _isOkToFail) throws IOException, ObjectDoesNotExistException, PropertyVetoException {
+    private void runCommand(final AS400 _as400, final String _cmd, final boolean _isOkToFail)
+            throws IOException, ObjectDoesNotExistException, PropertyVetoException {
         runCommand(m_logger, _as400, _cmd, _isOkToFail);
     }
 

--- a/src/main/java/com/github/theprez/appinstall/InstallationTask.java
+++ b/src/main/java/com/github/theprez/appinstall/InstallationTask.java
@@ -4,8 +4,10 @@ import java.beans.PropertyVetoException;
 import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 import com.github.theprez.jcmdutils.AppLogger;
 import com.github.theprez.jcmdutils.ConsoleQuestionAsker;
@@ -29,7 +31,8 @@ public class InstallationTask {
         m_config = _config;
     }
 
-    public void run(InstallOptions installOptions) throws IOException, InterruptedException, ObjectDoesNotExistException, PropertyVetoException {
+    public void run(InstallOptions installOptions)
+            throws IOException, InterruptedException, ObjectDoesNotExistException, PropertyVetoException {
         final DefaultLogger childLogger = new DefaultLogger(true);
         {
             final File preinstall = new File(m_dir, ".preinstall");
@@ -54,7 +57,8 @@ public class InstallationTask {
                 }
                 if (Character.isUpperCase(cmd.trim().charAt(0))) { // CL command
                     final String doctoredCmd = cmd.replace("$PWD", m_dir.getAbsolutePath());
-                    InstallPackageBuilder.runCommand(m_logger, as400, doctoredCmd, cmd.trim().toUpperCase().startsWith("DLT"));
+                    InstallPackageBuilder.runCommand(m_logger, as400, doctoredCmd,
+                            cmd.trim().toUpperCase().startsWith("DLT"));
                 } else {
                     m_logger.printfln_verbose("Running command '%s'", cmd);
                     final Process p = Runtime.getRuntime().exec(new String[] { "/QOpenSys/usr/bin/sh", "-c", cmd },
@@ -89,71 +93,143 @@ public class InstallationTask {
 
     /**
      * @param files
-     * @param _confirm Specify 'y' to always confirm, specify 'c' to confirm only non-delete actions
+     * @param _confirm Specify 'y' to always confirm, specify 'c' to confirm only
+     *                 non-delete actions
      */
     private List<String> inferCommandsFromFileList(List<String> files, InstallOptions installOptions)
             throws UnsupportedEncodingException, IOException {
         List<String> manifestCommands = new LinkedList<String>();
         String confirmationMsg = "\n\n\nIf you continue, the following actions will be taken on your system:\n\n";
         for (String file : files) {
-        	// Restore file action
             if (file.endsWith(".tar")) {
+                // Restore file action
                 File tarFile = new File(m_dir, file);
-                final String untarCmd = "/QOpenSys/usr/bin/tar xvf " + tarFile.getAbsolutePath() + " -C /.";
-                manifestCommands.add(untarCmd);
-                ProcessResult tarlist = ProcessLauncher.exec("/QOpenSys/usr/bin/tar tvf " + tarFile.getAbsolutePath());
-                if (0 != tarlist.getExitStatus()) {
+
+                ProcessResult tarInfolist = ProcessLauncher
+                        .exec("/QOpenSys/usr/bin/tar tvf " + tarFile.getAbsolutePath());
+                if (0 != tarInfolist.getExitStatus()) {
                     throw new IOException("Error processing saved stream file data");
                 }
-                confirmationMsg += StringUtils.colorizeForTerminal("  - The following stream files will be installed:\n", TerminalColor.YELLOW);
-                for (String line : tarlist.getStdout()) {
-                    confirmationMsg += "        " + StringUtils.colorizeForTerminal(line, TerminalColor.CYAN) + "\n";
+                ProcessResult tarPathList = ProcessLauncher
+                        .exec("/QOpenSys/usr/bin/tar tf " + tarFile.getAbsolutePath());
+                if (0 != tarPathList.getExitStatus()) {
+                    throw new IOException("Error processing saved stream file data");
                 }
-                confirmationMsg += "\n";
-            // Restore library action
+
+                List<String> infoList = tarInfolist.getStdout();
+                List<String> pathList = tarPathList.getStdout();
+
+                if (infoList.size() != pathList.size()) {
+                    throw new IOException("Mismatch between tar info and file list outputs");
+                }
+
+                Map<String, String> willInstall = new LinkedHashMap<>();
+                Map<String, String> willNotInstall = new LinkedHashMap<>();
+                Map<String, String> willOverwrite = new LinkedHashMap<>();
+
+                for (int i = 0; i < infoList.size(); i++) {
+                    String info = infoList.get(i);
+                    String path = pathList.get(i);
+
+                    File destFile = new File(path);
+
+                    if (destFile.exists()) {
+                        if (file.endsWith("IfMissing.tar")) {
+                            willNotInstall.put(path, info);
+                        } else {
+                            willOverwrite.put(path, info);
+                        }
+                    } else {
+                        willInstall.put(path, info);
+                    }
+                }
+
+                if (!willInstall.isEmpty()) {
+                    confirmationMsg += StringUtils.colorizeForTerminal(
+                            "  - The following stream files will be installed:\n", TerminalColor.YELLOW);
+                    for (String path : willInstall.values()) {
+                        confirmationMsg += "        " + StringUtils.colorizeForTerminal(path, TerminalColor.CYAN)
+                                + "\n";
+                    }
+                    confirmationMsg += "\n";
+                }
+
+                if (!willOverwrite.isEmpty()) {
+                    confirmationMsg += StringUtils.colorizeForTerminal(
+                            "  - The following stream files will be deleted from the system and replaced with the version included in this bundle:\n",
+                            TerminalColor.BRIGHT_RED);
+                    for (String path : willOverwrite.values()) {
+                        confirmationMsg += "        " + StringUtils.colorizeForTerminal(path, TerminalColor.CYAN)
+                                + "\n";
+                    }
+                    confirmationMsg += "\n";
+                }
+
+                if (!willNotInstall.isEmpty()) {
+                    confirmationMsg += StringUtils.colorizeForTerminal(
+                            "  - The following stream files already exist and will not be installed:\n",
+                            TerminalColor.PURPLE);
+                    for (String path : willNotInstall.values()) {
+                        confirmationMsg += "        " + StringUtils.colorizeForTerminal(path, TerminalColor.CYAN)
+                                + "\n";
+                    }
+                    confirmationMsg += "\n";
+                }
+
+                // Construct untar command
+                String untarCmd = "/QOpenSys/usr/bin/tar xvf " + tarFile.getAbsolutePath() + " -C /.";
+                if (!willNotInstall.isEmpty()) {
+                    for (String path : willInstall.keySet()) {
+                        untarCmd += " " + path;
+                    }
+                }
+                manifestCommands.add(untarCmd);
             } else if (file.endsWith(".lib")) {
+                // Restore library action
                 String savlib = file.replace(".lib", "").trim();
                 String rstlib = installOptions.rstlib != null ? installOptions.rstlib : savlib;
                 if (!installOptions.lodrun && libraryExists(rstlib)) {
-                    confirmationMsg += 
-                            StringUtils.colorizeForTerminal("  - Library "+rstlib.toUpperCase()+" will be deleted from the system",
-                                    TerminalColor.BRIGHT_RED)+
-                            " and replaced with the version included in this bundle\n\n";
+                    confirmationMsg += StringUtils.colorizeForTerminal(
+                            "  - Library " + rstlib.toUpperCase()
+                                    + " will be deleted from the system and replaced with the version included in this bundle\n\n",
+                            TerminalColor.BRIGHT_RED);
                 } else {
-                    confirmationMsg += 
-                            StringUtils.colorizeForTerminal("  - Library "+rstlib.toUpperCase()+
-                            " will be installed on the system\n\n", TerminalColor.YELLOW) ;
+                    confirmationMsg += StringUtils.colorizeForTerminal("  - Library " + rstlib.toUpperCase() +
+                            " will be installed on the system\n\n", TerminalColor.YELLOW);
                 }
 
                 manifestCommands.add("CRTSAVF QTEMP/" + savlib);
                 manifestCommands.add("CPYFRMSTMF FROMSTMF('$PWD/" + file + "') TOMBR('/qsys.lib/qtemp.lib/" + savlib
                         + ".file') MBROPT(*REPLACE) CVTDTA(*NONE) ENDLINFMT(*FIXED) TABEXPN(*NO)");
                 if (!installOptions.lodrun) {
-	                manifestCommands.add("DLTLIB " + rstlib);
-	                String rstlibCmd = "RSTLIB SAVLIB(" + savlib + ") DEV(*SAVF) SAVF(QTEMP/" + savlib
-	                        + ") MBROPT(*ALL) ALWOBJDIF(*ALL) RSTLIB(" + rstlib + ')';
-	                if (installOptions.rstasp != null)
-	                	rstlibCmd += " RSTASP(" + installOptions.rstasp + ')';
-	                if (installOptions.rstaspdev != null)
-	                	rstlibCmd += " RSTASPDEV(" + installOptions.rstaspdev + ')';
-	                manifestCommands.add(rstlibCmd);
+                    manifestCommands.add("DLTLIB " + rstlib);
+                    String rstlibCmd = "RSTLIB SAVLIB(" + savlib + ") DEV(*SAVF) SAVF(QTEMP/" + savlib
+                            + ") MBROPT(*ALL) ALWOBJDIF(*ALL) RSTLIB(" + rstlib + ')';
+                    if (installOptions.rstasp != null)
+                        rstlibCmd += " RSTASP(" + installOptions.rstasp + ')';
+                    if (installOptions.rstaspdev != null)
+                        rstlibCmd += " RSTASPDEV(" + installOptions.rstaspdev + ')';
+                    manifestCommands.add(rstlibCmd);
                 }
-            // LODRUN action
             } else if (file.equals("qinstapp.pgm")) {
-            	if (installOptions.lodrun) {
-	            	confirmationMsg += StringUtils.colorizeForTerminal("  - LODRUN DEV(*SAVF) SAVF(QTEMP/QINSTAPP) will be run:\n", TerminalColor.YELLOW);
-	                manifestCommands.add("CRTSAVF QTEMP/QINSTAPP");
-	                manifestCommands.add("CPYFRMSTMF FROMSTMF('$PWD/" + file + "') TOMBR('/qsys.lib/qtemp.lib/qinstapp.file') MBROPT(*REPLACE) CVTDTA(*NONE) ENDLINFMT(*FIXED) TABEXPN(*NO)");
-	                manifestCommands.add("LODRUN DEV(*SAVF) SAVF(QTEMP/QINSTAPP)");
-            	}
+                // LODRUN action
+                if (installOptions.lodrun) {
+                    confirmationMsg += StringUtils.colorizeForTerminal(
+                            "  - LODRUN DEV(*SAVF) SAVF(QTEMP/QINSTAPP) will be run:\n", TerminalColor.YELLOW);
+                    manifestCommands.add("CRTSAVF QTEMP/QINSTAPP");
+                    manifestCommands.add("CPYFRMSTMF FROMSTMF('$PWD/" + file
+                            + "') TOMBR('/qsys.lib/qtemp.lib/qinstapp.file') MBROPT(*REPLACE) CVTDTA(*NONE) ENDLINFMT(*FIXED) TABEXPN(*NO)");
+                    manifestCommands.add("LODRUN DEV(*SAVF) SAVF(QTEMP/QINSTAPP)");
+                }
             }
         }
         System.out.println(confirmationMsg);
-        if (installOptions.confirm=='y' || (installOptions.confirm=='c' && !confirmationMsg.contains("delete"))) {
+        if (installOptions.confirm == 'y' || (installOptions.confirm == 'c' && !confirmationMsg.contains("delete"))) {
             m_logger.println_warn("Continuing without confirmation");
-        } else{
+        } else {
             ConsoleQuestionAsker asker = new ConsoleQuestionAsker();
-            boolean reply = asker.askBooleanQuestion(m_logger, "N", "Are you sure you want to proceed? (y/N)", (Object)null);
+            boolean reply = asker.askBooleanQuestion(m_logger, "N", "Are you sure you want to proceed? (y/N)",
+                    (Object) null);
             if (!reply) {
                 throw new IOException("Canceled by user");
             }


### PR DESCRIPTION
New options when creating the jar:
* `--fileIfMissing`: Same as `--file`, but only installs if missing
* `--dirIfMissing`: Same as `--dir`, but only installs if missing

This change was required in order to support https://github.com/ThePrez/Manzan/issues/245